### PR TITLE
Don't import 1s bans

### DIFF
--- a/AdKats.cs
+++ b/AdKats.cs
@@ -38413,6 +38413,12 @@ namespace PRoConEvents
                         switch (cBan.BanLength.Subset)
                         {
                             case TimeoutSubset.TimeoutSubsetType.Seconds:
+                                //Don't import bans 1s or less.  BA/BF4DB kick players using 1s bans.
+                                if (cBan.BanLength.Seconds <= 1)
+                                {
+                                    Log.Debug(() => "Skipping import of ban with 1 second length, likely from BA/BF4DB plugins", 5);
+                                    continue;
+                                }
                                 record.command_type = GetCommandByKey("player_ban_temp");
                                 record.command_action = GetCommandByKey("player_ban_temp");
                                 record.command_numeric = cBan.BanLength.Seconds / 60;


### PR DESCRIPTION
The new BA/BF4DB plugin updates to fix some ban workarounds the cheaters had found is done by creating 1 second bans.  This causes the adkats_bans table to be flooded with unnecessary ban entries.  For people with multiple popular servers this can render BFACP's banlist very difficult to use due to the massive numbers of kicks, and by extension bans created by the BA/BF4DB plugins.

This avoids the issue by not importing bans of 1 second or less (not that 0s should get through anyway but I'm not overly familiar with Procon/AdKats code or even C# for that matter).  If `== 1` is just as appropriate as `<= 1` feel free to change it.

I've been using this for about 5 hours now and it's working great whereas before I was getting 8-10 logged kicks/temp bans every hour or so from BA/BF4DB kicks.