### PR TITLE
Proxy support

### DIFF
--- a/AdKats.cs
+++ b/AdKats.cs
@@ -9006,31 +9006,31 @@ namespace PRoConEvents
                             return;
                     }
                 }
-            }
-            else if (Regex.Match(strVariable, @"Use Proxy for Battlelog").Success)
-            {
-                _UseProxy = Boolean.Parse(strValue);
-                if (_UseProxy && _firstPlayerListComplete && String.IsNullOrEmpty(_ProxyURL))
+                else if (Regex.Match(strVariable, @"Use Proxy for Battlelog").Success)
                 {
-                    Log.Warn("The 'Proxy URL' setting must be filled in before using a proxy.");
+                    _UseProxy = Boolean.Parse(strValue);
+                    if (_UseProxy && _firstPlayerListComplete && String.IsNullOrEmpty(_ProxyURL))
+                    {
+                        Log.Warn("The 'Proxy URL' setting must be filled in before using a proxy.");
+                    }
+                    QueueSettingForUpload(new CPluginVariable(@"Use Proxy for Battlelog", typeof(Boolean), _UseProxy));
                 }
-                QueueSettingForUpload(new CPluginVariable(@"Use Proxy for Battlelog", typeof(Boolean), _UseProxy));
-            }
-            else if (Regex.Match(strVariable, @"Proxy URL").Success)
-            {
-                try
+                else if (Regex.Match(strVariable, @"Proxy URL").Success)
                 {
-                    Uri uri = new Uri(strValue);
-                    Log.Debug(() => "Proxy URL set to " + strValue + ".", 1);
-                }
-                catch(UriFormatException)
-                {
-                    strValue = "";
-                    Log.Warn("Invalid Proxy URL! Make sure that the URI is valid!");
-                }
+                    try
+                    {
+                        Uri uri = new Uri(strValue);
+                        Log.Debug(() => "Proxy URL set to " + strValue + ".", 1);
+                    }
+                    catch(UriFormatException)
+                    {
+                        strValue = "";
+                        Log.Warn("Invalid Proxy URL! Make sure that the URI is valid!");
+                    }
 
-                _ProxyURL = strValue;
-                QueueSettingForUpload(new CPluginVariable(@"Proxy URL", typeof(String), _ProxyURL));
+                    _ProxyURL = strValue;
+                    QueueSettingForUpload(new CPluginVariable(@"Proxy URL", typeof(String), _ProxyURL));
+                }
             }
             catch (Exception e)
             {

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -48885,7 +48885,7 @@ namespace PRoConEvents
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
-                            client.Proxy = new WebProxy(_ProxyURL, true); 
+                            Util.SetWebClientProxy(client, _ProxyURL);
                         }
                         try
                         {
@@ -48950,7 +48950,7 @@ namespace PRoConEvents
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
-                            client.Proxy = new WebProxy(_ProxyURL, true); 
+                            Util.SetWebClientProxy(client, _ProxyURL);
                         }
                         try
                         {
@@ -49107,7 +49107,7 @@ namespace PRoConEvents
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
-                            client.Proxy = new WebProxy(_ProxyURL, true); 
+                            Util.SetWebClientProxy(client, _ProxyURL);
                         }
                         try
                         {
@@ -49249,7 +49249,7 @@ namespace PRoConEvents
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
-                        client.Proxy = new WebProxy(_ProxyURL, true); 
+                         Util.SetWebClientProxy(client, _ProxyURL);
                     }
                     try
                     {
@@ -49452,7 +49452,7 @@ namespace PRoConEvents
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
-                        client.Proxy = new WebProxy(_ProxyURL, true); 
+                        Util.SetWebClientProxy(client, _ProxyURL);
                     }               
                     try
                     {
@@ -49695,7 +49695,7 @@ namespace PRoConEvents
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
-                        client.Proxy = new WebProxy(_ProxyURL, true); 
+                        Util.SetWebClientProxy(client, _ProxyURL);
                     }
                     try
                     {
@@ -51200,6 +51200,25 @@ namespace PRoConEvents
             public Utilities(Logger log)
             {
                 Log = log;
+            }
+            
+            public void SetWebClientProxy(WebClient wClient, String proxyURL)
+            {
+                if(!String.IsNullOrEmpty(proxyURL))
+                {
+                    Uri uri = new Uri(proxyURL);
+                    wClient.Proxy = new WebProxy(proxyURL, true); 
+                    if (!String.IsNullOrEmpty(uri.UserInfo))
+                    {
+                        string[] parameters = uri.UserInfo.Split(':');
+                        if (parameters.Length < 2) 
+                        {
+                            Log.Warn("Invalid URI auth data!");
+                            return;
+                        }
+                        wClient.Proxy.Credentials = new NetworkCredential(parameters[0], parameters[1]);
+                    }
+                }
             }
 
             public String ClientDownloadTimer(WebClient wClient, String url)

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -21,11 +21,9 @@
  * Development by Daniel J. Gradinjan (ColColonCleaner)
  * 
  * AdKats.cs
- * Version 7.6.0.9
- * 16-MAY-2020
  * 
  * Automatic Update Information
- * <version_code>7.6.0.9</version_code>
+ * <version_code>7.6.0.10</version_code>
  */
 
 using System;
@@ -68,7 +66,7 @@ namespace PRoConEvents
     {
 
         //Current Plugin Version
-        private const String PluginVersion = "7.6.0.9";
+        private const String PluginVersion = "7.6.0.10";
 
         public enum GameVersionEnum
         {

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -21,6 +21,8 @@
  * Development by Daniel J. Gradinjan (ColColonCleaner)
  * 
  * AdKats.cs
+ * Version 7.6.0.10
+ * 06-APR-2020
  * 
  * Automatic Update Information
  * <version_code>7.6.0.10</version_code>

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -3388,7 +3388,7 @@ namespace PRoConEvents
                     {
                         return;
                     }
-                    using (WebClient client = new WebClient())
+                    using (WebClient client = new GZipWebClient())
                     {
                         try
                         {
@@ -9471,7 +9471,7 @@ namespace PRoConEvents
                     Thread.CurrentThread.Name = "DescFetching";
                     _pluginDescFetchProgress = "Started";
                     //Create web client
-                    WebClient client = new WebClient();
+                    WebClient client = new GZipWebClient();
                     //Download the readme and changelog
                     Log.Debug(() => "Fetching plugin links...", 2);
                     try
@@ -38819,7 +38819,7 @@ namespace PRoConEvents
                 {
                     using (MySqlCommand command = connection.CreateCommand())
                     {
-                        WebClient client = new WebClient();
+                        WebClient client = new GZipWebClient();
                         Log.Debug(() => "Fetching plugin changelog...", 2);
                         try
                         {
@@ -47514,7 +47514,7 @@ namespace PRoConEvents
         public Boolean GetGlobalUTCTimestamp(out DateTime globalUTCTime)
         {
             globalUTCTime = UtcNow();
-            using (WebClient client = new WebClient())
+            using (WebClient client = new GZipWebClient())
             {
                 try
                 {
@@ -48878,7 +48878,7 @@ namespace PRoConEvents
                 if (GameVersion == GameVersionEnum.BF3)
                 {
                     Log.Debug(() => "Preparing to fetch battlelog info for BF3 player " + aPlayer.GetVerboseName(), 7);
-                    using (WebClient client = new WebClient())
+                    using (WebClient client = new GZipWebClient())
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
@@ -48943,7 +48943,7 @@ namespace PRoConEvents
                 else if (GameVersion == GameVersionEnum.BF4)
                 {
                     Log.Debug(() => "Preparing to fetch battlelog info for BF4 player " + aPlayer.GetVerboseName(), 7);
-                    using (WebClient client = new WebClient())
+                    using (WebClient client = new GZipWebClient())
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
@@ -49100,7 +49100,7 @@ namespace PRoConEvents
                 else if (GameVersion == GameVersionEnum.BFHL)
                 {
                     Log.Debug(() => "Preparing to fetch battlelog info for BFHL player " + aPlayer.GetVerboseName(), 7);
-                    using (WebClient client = new WebClient())
+                    using (WebClient client = new GZipWebClient())
                     {
                         if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                         {
@@ -49242,7 +49242,7 @@ namespace PRoConEvents
             }
             if (GameVersion == GameVersionEnum.BF3)
             {
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
@@ -49445,7 +49445,7 @@ namespace PRoConEvents
             }
             else if (GameVersion == GameVersionEnum.BF4)
             {
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
@@ -49688,7 +49688,7 @@ namespace PRoConEvents
             }
             else if (GameVersion == GameVersionEnum.BFHL)
             {
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     if(_UseProxy && !String.IsNullOrEmpty(_ProxyURL))
                     {
@@ -49841,7 +49841,7 @@ namespace PRoConEvents
         {
             Log.Debug(() => "Entering FetchAdKatsReputationDefinitions", 7);
             ArrayList repTable = null;
-            using (WebClient client = new WebClient())
+            using (WebClient client = new GZipWebClient())
             {
                 String repInfo;
                 Log.Debug(() => "Fetching reputation definitions...", 2);
@@ -49912,7 +49912,7 @@ namespace PRoConEvents
         {
             Log.Debug(() => "Entering FetchASpecialGroupDefinitions", 7);
             List<ASpecialGroup> SpecialGroupsList = null;
-            using (WebClient client = new WebClient())
+            using (WebClient client = new GZipWebClient())
             {
                 String groupInfo;
                 Log.Debug(() => "Fetching special group definitions...", 2);
@@ -50120,7 +50120,7 @@ namespace PRoConEvents
         {
             Log.Debug(() => "Entering FetchSQLUpdates", 7);
             List<ASQLUpdate> SQLUpdates = new List<ASQLUpdate>();
-            using (WebClient client = new WebClient())
+            using (WebClient client = new GZipWebClient())
             {
                 try
                 {
@@ -51171,6 +51171,24 @@ namespace PRoConEvents
                 }
             }
         }
+        
+        public class GZipWebClient : WebClient
+        {
+            private String ua;
+    
+            public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; AdKats)")
+            {
+                this.ua = ua;
+            }
+            
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                HttpWebRequest request = (HttpWebRequest)base.GetWebRequest(address);
+                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                request.UserAgent = ua;
+                return request;
+            }
+        }
 
         public class Utilities
         {
@@ -51345,7 +51363,7 @@ namespace PRoConEvents
             if (false && _UseExperimentalTools && GameVersion == GameVersionEnum.BF4)
             {
                 String externalPluginSource;
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     try
                     {
@@ -51459,7 +51477,7 @@ namespace PRoConEvents
             if (!String.IsNullOrEmpty(_AdKatsLRTExtensionToken))
             {
                 String extensionSource;
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     try
                     {
@@ -51608,7 +51626,7 @@ namespace PRoConEvents
                                 Log.Info("Preparing to download plugin update to version " + _latestPluginVersion);
                             }
                             String pluginSource = null;
-                            using (WebClient client = new WebClient())
+                            using (WebClient client = new GZipWebClient())
                             {
                                 try
                                 {
@@ -52824,7 +52842,7 @@ namespace PRoConEvents
                 return;
             }
             IPAPILocation loc = new IPAPILocation(aPlayer.player_ip);
-            using (WebClient client = new WebClient())
+            using (WebClient client = new GZipWebClient())
             {
                 try
                 {
@@ -61494,7 +61512,7 @@ namespace PRoConEvents
             {
                 _plugin.Log.Debug(() => "Entering FetchAWeaponNames", 7);
                 Hashtable weaponNames = null;
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     String downloadString;
                     _plugin.Log.Debug(() => "Fetching weapon names...", 2);
@@ -62694,7 +62712,7 @@ namespace PRoConEvents
             private Hashtable FetchWeaponDefinitions()
             {
                 Hashtable statTable = null;
-                using (WebClient client = new WebClient())
+                using (WebClient client = new GZipWebClient())
                 {
                     String weaponInfo;
                     Plugin.Log.Debug(() => "Fetching weapon statistic definitions...", 2);
@@ -62885,7 +62903,7 @@ namespace PRoConEvents
                     //Attempt to fetch and parse
                     if (!String.IsNullOrEmpty(widgetURL))
                     {
-                        using (WebClient client = new WebClient())
+                        using (WebClient client = new GZipWebClient())
                         {
                             try
                             {

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -9019,12 +9019,15 @@ namespace PRoConEvents
                 {
                     try
                     {
-                        Uri uri = new Uri(strValue);
-                        Log.Debug(() => "Proxy URL set to " + strValue + ".", 1);
+                        if (!String.IsNullOrEmpty(strValue))
+                        {
+                            Uri uri = new Uri(strValue);
+                            Log.Debug(() => "Proxy URL set to " + strValue + ".", 1);
+                        }
                     }
                     catch(UriFormatException)
                     {
-                        strValue = "";
+                        strValue = _ProxyURL;
                         Log.Warn("Invalid Proxy URL! Make sure that the URI is valid!");
                     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1111,3 +1111,22 @@ Added small improvements to fuzzy player match response text.</li>
 <ul>
     <li><b>No upgrade SQL required.</b></li>
 </ul>
+
+<h4>7.6.0.10 (06-APR-2021)</h4>
+<b>Enhancements</b><br/>
+<ul>
+	<li>Add Proxy Support</li>
+</ul>
+<b>Changes</b><br/>
+<ul>
+    <li>New Settings for proxy</li>
+    <li>Usage of proxy</li>
+</ul>
+<b>Bugs Fixed</b><br/>
+<ul>
+	<li>No Bug Fixes</li>
+</ul>
+<b>Upgrade SQL from 4.0.0.0 - Current</b><br/>
+<ul>
+    <li><b>No upgrade SQL required.</b></li>
+</ul>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[//]: # "<latest_stable_release>7.6.0.9</latest_stable_release>"
+[//]: # "<latest_stable_release>7.6.0.10</latest_stable_release>"
 <p>
     <a name=adkats />
     <img src="https://i.imgur.com/r9pwH3A.png" alt="AdKats Advanced In-Game Admin Tools">
@@ -4200,5 +4200,14 @@ plugin.CallOtherPlugin("AdKats", "IssueCommand", command);
     <li><b>'Command Entry'</b> -
         Enter commands here just like in game, mainly for debug purposes. 
         Don't let more than one person use this at any time.
+    </li>
+</ul>
+<h3>X98. Proxy Settings:</h3>
+<ul>
+    <li><b>'Use Proxy for Battlelog'</b> -
+        Send all battlelog requests over a proxy server.
+    </li>
+    <li><b>'Proxy URL'</b> -
+        The full URI of the proxy in the format `http://IP:PORT` or `http://USER:PW@IP:PORT`.
     </li>
 </ul>


### PR DESCRIPTION
This pull request would do the following:
* Raise the version by 1
* Add a new setting section X98 Proxy Settings
* Add two settings (Enable Proxy for Battlelog, Proxy URL) + Validation
* Add a WebProxy to 6 WebClients if the setting is enabled and a valid proxy is set.

The last part is redundant. Moving the blocks into one layer above before the split between BF3,4,HL would reduce it to two definitions.
Also I create a new WebProxy object on every new request. Did not want to cache it somewhere as a member, or make it static.

Reason:
Battlelog has been having a 20 requests / minute / per IP (or smth like that) since the last weekend. I bypass this limit by sending all requests to battlelog through a round robin proxy provider. Maybe this might be helpful for others?

Tested and working.