### PR TITLE
Fix broken links: redirect Hedius/E4GLAdKats URLs to AdKats/AdKats

### DIFF
--- a/src/AdKats.cs
+++ b/src/AdKats.cs
@@ -1124,7 +1124,7 @@ namespace PRoConEvents
 
         public String GetPluginName()
         {
-            return "E4GLAdKats - Advanced In-Game Admin";
+            return "AdKats - Advanced In-Game Admin";
         }
 
         public String GetPluginVersion()
@@ -1139,15 +1139,15 @@ namespace PRoConEvents
 
         public String GetPluginWebsite()
         {
-            return "github.com/Hedius/E4GLAdKats";
+            return "github.com/AdKats/AdKats";
         }
 
         public String GetPluginDescription()
         {
             String concat = @"
             <p>
-                <a href='https://github.com/Hedius/E4GLAdKats' name=adkats>
-                    <img src='https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/images/AdKats.jpg' alt='AdKats Advanced In-Game Admin Tools'>
+                <a href='https://github.com/AdKats/AdKats' name=adkats>
+                    <img src='https://raw.githubusercontent.com/AdKats/AdKats/master/images/AdKats.jpg' alt='AdKats Advanced In-Game Admin Tools'>
                 </a>
             </p>";
             try
@@ -1633,7 +1633,7 @@ namespace PRoConEvents
                     Log.Debug(() => "Fetching plugin links...", 2);
                     try
                     {
-                        _pluginLinks = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/LINKS.md?cacherand=" + Environment.TickCount);
+                        _pluginLinks = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/LINKS.md?cacherand=" + Environment.TickCount);
                         Log.Debug(() => "Plugin links fetched.", 1);
                     }
                     catch (Exception)
@@ -1652,7 +1652,7 @@ namespace PRoConEvents
                     Log.Debug(() => "Fetching plugin readme...", 2);
                     try
                     {
-                        _pluginDescription = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/README.md?cacherand=" + Environment.TickCount);
+                        _pluginDescription = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/README.md?cacherand=" + Environment.TickCount);
                         Log.Debug(() => "Plugin readme fetched.", 1);
                     }
                     catch (Exception)
@@ -1671,7 +1671,7 @@ namespace PRoConEvents
                     Log.Debug(() => "Fetching plugin changelog...", 2);
                     try
                     {
-                        _pluginChangelog = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/CHANGELOG.md?cacherand=" + Environment.TickCount);
+                        _pluginChangelog = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/CHANGELOG.md?cacherand=" + Environment.TickCount);
                         Log.Debug(() => "Plugin changelog fetched.", 1);
                     }
                     catch (Exception)
@@ -1715,7 +1715,7 @@ namespace PRoConEvents
                                     <h2 style='color:#DF0101;'>
                                         You are running an outdated version! Version " + latestStableVersion + @" is available for download!
                                     </h2>
-                                    <a href='https://github.com/Hedius/E4GLAdKats/' target='_blank'>
+                                    <a href='https://github.com/AdKats/AdKats/' target='_blank'>
                                         Download Version " + latestStableVersion + @"!
                                     </a><br/>
                                     Download link below.";

--- a/src/AdKats/Database.cs
+++ b/src/AdKats/Database.cs
@@ -1139,7 +1139,7 @@ namespace PRoConEvents
                     Log.Debug(() => "Fetching plugin changelog...", 2);
                     try
                     {
-                        sqlScript = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkats.sql?cacherand=" + Environment.TickCount);
+                        sqlScript = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkats.sql?cacherand=" + Environment.TickCount);
                         Log.Debug(() => "SQL setup script fetched.", 1);
                     }
                     catch (Exception)
@@ -8356,7 +8356,7 @@ namespace PRoConEvents
             Log.Debug(() => "Fetching reputation definitions...", 2);
             try
             {
-                repInfo = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkatsreputationstats.json" + "?cacherand=" + Environment.TickCount);
+                repInfo = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkatsreputationstats.json" + "?cacherand=" + Environment.TickCount);
                 Log.Debug(() => "Reputation definitions fetched.", 1);
             }
             catch (Exception)
@@ -8391,7 +8391,7 @@ namespace PRoConEvents
             Log.Debug(() => "Fetching special group definitions...", 2);
             try
             {
-                groupInfo = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkatsspecialgroups.json" + "?cacherand=" + Environment.TickCount);
+                groupInfo = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkatsspecialgroups.json" + "?cacherand=" + Environment.TickCount);
                 Log.Debug(() => "Special group definitions fetched.", 1);
             }
             catch (Exception)
@@ -8482,7 +8482,7 @@ namespace PRoConEvents
                 String updateInfo;
                 try
                 {
-                    updateInfo = Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkatsupdates.json" + "?cacherand=" + Environment.TickCount);
+                    updateInfo = Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkatsupdates.json" + "?cacherand=" + Environment.TickCount);
                     Log.Debug(() => "SQL updates fetched.", 1);
                 }
                 catch (Exception)

--- a/src/AdKats/Integrations.cs
+++ b/src/AdKats/Integrations.cs
@@ -403,7 +403,7 @@ namespace PRoConEvents
                 _plugin.Log.Debug(() => "Fetching weapon names...", 2);
                 try
                 {
-                    downloadString = _plugin.Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkatsweaponnames.json" + "?cacherand=" + Environment.TickCount);
+                    downloadString = _plugin.Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkatsweaponnames.json" + "?cacherand=" + Environment.TickCount);
                     _plugin.Log.Debug(() => "Weapon names fetched.", 1);
                 }
                 catch (Exception)

--- a/src/AdKats/Utilities.cs
+++ b/src/AdKats/Utilities.cs
@@ -487,8 +487,8 @@ namespace PRoConEvents
                             String pluginSource = null;
                             try
                             {
-                                string stableURL = "https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/AdKats.cs" + "?cacherand=" + Environment.TickCount;
-                                string testURL = "https://raw.githubusercontent.com/Hedius/E4GLAdKats/test/AdKats.cs" + "?cacherand=" + Environment.TickCount;
+                                string stableURL = "https://raw.githubusercontent.com/AdKats/AdKats/master/AdKats.cs" + "?cacherand=" + Environment.TickCount;
+                                string testURL = "https://raw.githubusercontent.com/AdKats/AdKats/test/AdKats.cs" + "?cacherand=" + Environment.TickCount;
                                 if (_pluginVersionStatus == VersionStatus.OutdatedBuild)
                                 {
                                     pluginSource = Util.HttpDownload(stableURL);
@@ -1867,7 +1867,7 @@ namespace PRoConEvents
                 Plugin.Log.Debug(() => "Fetching weapon statistic definitions...", 2);
                 try
                 {
-                    weaponInfo = Plugin.Util.HttpDownload("https://raw.githubusercontent.com/Hedius/E4GLAdKats/main/adkatsblweaponstats.json" + "?cacherand=" + Environment.TickCount);
+                    weaponInfo = Plugin.Util.HttpDownload("https://raw.githubusercontent.com/AdKats/AdKats/master/adkatsblweaponstats.json" + "?cacherand=" + Environment.TickCount);
                     Plugin.Log.Debug(() => "Weapon statistic definitions fetched.", 1);
                 }
                 catch (Exception)


### PR DESCRIPTION
Update all GitHub raw content URLs and repo references from
Hedius/E4GLAdKats (main branch) to AdKats/AdKats (master branch).
Hedius remains credited as author and in code comments.

- Plugin name: E4GLAdKats -> AdKats
- Website URL: github.com/Hedius/E4GLAdKats -> github.com/AdKats/AdKats
- All raw.githubusercontent.com URLs updated (LINKS.md, README.md,
  CHANGELOG.md, adkats.sql, JSON configs, plugin auto-update)
- Branch references: main -> master